### PR TITLE
Update MemoryCache to use KeyValuePair enumerator from concurrent dictionary

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -316,8 +316,11 @@ namespace Microsoft.Extensions.Caching.Memory
         private static void ScanForExpiredItems(MemoryCache cache)
         {
             DateTimeOffset now = cache._lastExpirationScan = cache._options.Clock.UtcNow;
-            foreach (CacheEntry entry in cache._entries.Values)
+
+            foreach (KeyValuePair<object, CacheEntry> item in cache._entries)
             {
+                CacheEntry entry = item.Value;
+
                 if (entry.CheckExpired(now))
                 {
                     cache.RemoveEntry(entry);


### PR DESCRIPTION
Changed code to use KeyValuePair enumerator since this doesn't cause the whole _entries ConcurrentDictionary to lock as does accessing its .Values property.